### PR TITLE
Add image prefix check for remote video frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,12 @@
       videoRef.map().on((data, id) => {
         if (id !== userId) {
           if (data && data.frame) {
-            remoteVideo.src = data.frame;
+            // 安全性向上のため data:image/ 以外は表示しない
+            if (data.frame.startsWith('data:image/')) {
+              remoteVideo.src = data.frame;
+            } else {
+              remoteVideo.src = '';
+            }
           } else {
             remoteVideo.src = '';
           }


### PR DESCRIPTION
## Summary
- prevent non-image data from loading into the remote video element

## Testing
- `npm test` *(fails: could not find package.json)*
- `htmlhint index.html` *(fails: command not found)*